### PR TITLE
fix(day-one): hitting enter does not trigger timer

### DIFF
--- a/src/app/components/program/fiveMaxEffortSets/FiveMaxEffortSets.tsx
+++ b/src/app/components/program/fiveMaxEffortSets/FiveMaxEffortSets.tsx
@@ -6,12 +6,19 @@ import RepInput from "@/components/program/fiveMaxEffortSets/RepInput";
 import RepsCompleteButton from "@/components/program/fiveMaxEffortSets/RepsCompleteButton";
 import RepsRemoveButton from "@/components/program/fiveMaxEffortSets/RepsRemoveButton";
 import SetsTable from "@/components/program/fiveMaxEffortSets/SetsTable";
+import {createPortal} from "react-dom";
+import TimerModal from "../TimerModal";
+
+const recoveryTime = 90;
 
 const FiveMaxEffortSets = () => {
   let initialRepsArray: number[] = [];
 
   const [reps, setReps] = useState(0);
   const [repsArray, setRepsArray] = useState(initialRepsArray);
+  const [showTimerModal, setShowTimerModal] = useState(false);
+
+
 
   return (
     <section className={styles.repInfoSection}>
@@ -20,6 +27,7 @@ const FiveMaxEffortSets = () => {
         <RepsRemoveButton
           repsArrayState={repsArray}
           setStateForRepsArray={setRepsArray}
+          showTimerModalState={showTimerModal}
         />
       }
       {repsArray.length < 5 &&
@@ -28,14 +36,26 @@ const FiveMaxEffortSets = () => {
             onChange={setReps}
             onEnter={setRepsArray}
             repsArrayState={repsArray}
+            setStateForShowTimerModal={setShowTimerModal}
+            showTimerModalState={showTimerModal}
           />
           <RepsCompleteButton
             reps={reps}
             repsArrayState={repsArray}
             setStateForRepsArray={setRepsArray}
+            setStateForShowTimerModal={setShowTimerModal}
+            showTimerModalState={showTimerModal}
           />
         </>
       }
+      {showTimerModal && createPortal(
+        <TimerModal
+          onClose={() => setShowTimerModal(false)}
+          recoveryTime={recoveryTime}
+          setStateForShowTimerModal={setShowTimerModal}
+        />,
+        document.body
+      )}
     </section>
   )
 }

--- a/src/app/components/program/fiveMaxEffortSets/RepInput.tsx
+++ b/src/app/components/program/fiveMaxEffortSets/RepInput.tsx
@@ -11,9 +11,17 @@ interface RepInputProps {
   onChange: Dispatch<SetStateAction<number>>;
   onEnter: Dispatch<SetStateAction<number[]>>;
   repsArrayState: number[];
+  setStateForShowTimerModal: Dispatch<SetStateAction<boolean>>;
+  showTimerModalState: boolean;
 }
 
-const RepInput = ({ onChange, onEnter, repsArrayState }: RepInputProps) => {
+const RepInput = ({
+  onChange,
+  onEnter,
+  repsArrayState,
+  setStateForShowTimerModal,
+  showTimerModalState
+}: RepInputProps) => {
   const repInputId = useId();
 
   const [reps, setReps] = useState(0);
@@ -35,6 +43,7 @@ const RepInput = ({ onChange, onEnter, repsArrayState }: RepInputProps) => {
           reps
         ]
       );
+      setStateForShowTimerModal(true);
     }
   }
 
@@ -55,6 +64,7 @@ const RepInput = ({ onChange, onEnter, repsArrayState }: RepInputProps) => {
         value={reps}
         onChange={handleChange}
         onKeyUp={handleKeyUp}
+        disabled={showTimerModalState}
       />
     </section>
   )

--- a/src/app/components/program/fiveMaxEffortSets/RepsCompleteButton.tsx
+++ b/src/app/components/program/fiveMaxEffortSets/RepsCompleteButton.tsx
@@ -1,24 +1,23 @@
 import { Dispatch, SetStateAction, useState } from "react";
 import styles from './RepsActionButton.module.css';
 import {checkMarkButtonEmoji} from "@/emojis";
-import {createPortal} from "react-dom";
-import TimerModal from "../TimerModal";
 
 interface RepsCompleteButtonProps {
   reps: number;
   repsArrayState: number[];
   setStateForRepsArray: Dispatch<SetStateAction<number[]>>;
+  setStateForShowTimerModal: Dispatch<SetStateAction<boolean>>;
+  showTimerModalState: boolean;
 }
 
-const recoveryTime = 90;
 
 const RepsCompleteButton = ({
   reps,
   repsArrayState,
   setStateForRepsArray,
+  setStateForShowTimerModal,
+  showTimerModalState
 }: RepsCompleteButtonProps) => {
-  
-  const [showTimerModal, setShowTimerModal] = useState(false);
 
   function handleComplete() {
     setStateForRepsArray(
@@ -28,7 +27,7 @@ const RepsCompleteButton = ({
       ]
     );
 
-    setShowTimerModal(true);
+    setStateForShowTimerModal(true);
 
   };
 
@@ -38,17 +37,10 @@ const RepsCompleteButton = ({
         type='button'
         onClick={handleComplete}
         className={`${styles.button} ${styles.completeButton}`}
+        disabled={showTimerModalState}
       >
         {checkMarkButtonEmoji}
       </button>
-      {showTimerModal && createPortal(
-        <TimerModal
-          onClose={() => setShowTimerModal(false)}
-          recoveryTime={recoveryTime}
-          setStateForShowTimerModal={setShowTimerModal}
-        />,
-        document.body
-      )}
     </>
   );
 };

--- a/src/app/components/program/fiveMaxEffortSets/RepsRemoveButton.tsx
+++ b/src/app/components/program/fiveMaxEffortSets/RepsRemoveButton.tsx
@@ -5,9 +5,14 @@ import {counterClockwiseArrowsButtonEmoji} from "@/emojis";
 interface RepsRemoveButtonProps {
   setStateForRepsArray: Dispatch<SetStateAction<number[]>>;
   repsArrayState: number[];
+  showTimerModalState: boolean;
 }
 
-const RepsRemoveButton = ({ setStateForRepsArray, repsArrayState }: RepsRemoveButtonProps) => {
+const RepsRemoveButton = ({
+  setStateForRepsArray,
+  repsArrayState,
+  showTimerModalState
+}: RepsRemoveButtonProps) => {
 
   function handleRemove() {
     setStateForRepsArray(repsArrayState.slice(0, -1));
@@ -18,6 +23,7 @@ const RepsRemoveButton = ({ setStateForRepsArray, repsArrayState }: RepsRemoveBu
       type='button'
       onClick={handleRemove}
       className={`${styles.button} ${styles.removeButton}`}
+      disabled={showTimerModalState}
     >
       {counterClockwiseArrowsButtonEmoji}
     </button>

--- a/src/app/components/program/maxTrainingSets/MaxTrainingSetsDisplay.tsx
+++ b/src/app/components/program/maxTrainingSets/MaxTrainingSetsDisplay.tsx
@@ -49,12 +49,17 @@ const MaxTrainingSetsDisplay = ({
         )}
       </h3>
       <div className={styles.actionButtonsContainer}>
-        <button className={styles.actionButton} onClick={handleMiss}>
+        <button
+          className={styles.actionButton}
+          onClick={handleMiss}
+          disabled={showTimerModal}
+        >
           {crossMarkButtonEmoji}
         </button>
         <button
           className={styles.actionButton}
           onClick={handleComplete}
+          disabled={showTimerModal}
         >
           {checkMarkButtonEmoji}
         </button>

--- a/src/app/components/program/pyramid/ActionButton.module.css
+++ b/src/app/components/program/pyramid/ActionButton.module.css
@@ -1,4 +1,4 @@
-.completeButton {
+.pyramidActionButton {
   background: transparent;
   border: none;
   width: 3.5rem;

--- a/src/app/components/program/pyramid/MissSetButton.tsx
+++ b/src/app/components/program/pyramid/MissSetButton.tsx
@@ -1,18 +1,27 @@
+import styles from './ActionButton.module.css';
 import {crossMarkButtonEmoji} from "@/emojis";
 import { Dispatch, SetStateAction } from "react";
 
 interface MissSetButtonProps {
   onMissed: Dispatch<SetStateAction<boolean>>;
+  showTimerModalState: boolean;
 };
 
-const MissSetButton = ({ onMissed }: MissSetButtonProps) => {
+const MissSetButton = ({
+  onMissed,
+  showTimerModalState
+}: MissSetButtonProps) => {
 
   function handleMiss() {
     onMissed(true);
   }
 
   return (
-    <button onClick={handleMiss}>
+    <button
+      onClick={handleMiss}
+      disabled={showTimerModalState}
+      className={styles.pyramidActionButton}
+    >
       {crossMarkButtonEmoji}
     </button>
   )

--- a/src/app/components/program/pyramid/NumberedMissRepButton.tsx
+++ b/src/app/components/program/pyramid/NumberedMissRepButton.tsx
@@ -1,11 +1,8 @@
-import {createPortal} from 'react-dom';
 import styles from './NumberedMissRepButton.module.css';
 import {
   Dispatch,
   SetStateAction,
-  useState
 } from "react";
-import TimerModal from '../TimerModal';
 
 interface NumberedMissRepButtonProps {
   onMissed: Dispatch<SetStateAction<boolean>>;
@@ -14,6 +11,8 @@ interface NumberedMissRepButtonProps {
   setStateForReps: Dispatch<SetStateAction<number>>;
   setStateForRepsArray: Dispatch<SetStateAction<number[]>>;
   setStateForMaxNumbers: Dispatch<SetStateAction<boolean>>;
+  showTimerModalState: boolean;
+  setStateForShowTimerModal: Dispatch<SetStateAction<boolean>>;
 }
 
 const NumberedMissRepButton = ({
@@ -22,10 +21,10 @@ const NumberedMissRepButton = ({
   repsArrayState,
   setStateForReps,
   setStateForRepsArray,
-  setStateForMaxNumbers
+  setStateForMaxNumbers,
+  showTimerModalState,
+  setStateForShowTimerModal
 }: NumberedMissRepButtonProps) => {
-
-  const [showTimerModal, setShowTimerModal] = useState(false);
 
   const recoveryTime = 10 * repCount;
 
@@ -38,7 +37,7 @@ const NumberedMissRepButton = ({
       repCount
     ]);
 
-    setShowTimerModal(true);
+    setStateForShowTimerModal(true);
 
     setTimeout(() => {
       setStateForMaxNumbers(true);
@@ -52,18 +51,10 @@ const NumberedMissRepButton = ({
       <button
         className={styles.repButton}
         onClick={handleClick}
-        disabled={showTimerModal}
+        disabled={showTimerModalState}
       >
         {repCount}
       </button>
-      {showTimerModal && createPortal(
-        <TimerModal
-          onClose={() => setShowTimerModal(false)}
-          recoveryTime={recoveryTime}
-          setStateForShowTimerModal={setShowTimerModal}
-        />,
-        document.body
-      )}
     </>
   )
 };

--- a/src/app/components/program/pyramid/Pyramid.tsx
+++ b/src/app/components/program/pyramid/Pyramid.tsx
@@ -10,16 +10,19 @@ import DayComplete from "@/components/program/DayComplete";
 import PyramidDisplay from "@/components/program/pyramid/PyramidDisplay";
 import MissSetButton from "./MissSetButton";
 import NumberedMissRepButton from "./NumberedMissRepButton";
+import TimerModal from "@/components/program/TimerModal";
+import {createPortal} from "react-dom";
 
 const Pyramid = () => {
   let initialRepsArray: number[] = [];
 
-  const [reps, setReps] = useState(1);
+  const [completedReps, setCompletedReps] = useState(0);
   const [repsArray, setRepsArray] = useState(initialRepsArray);
   const [missed, setMissed] = useState(false);
   const [dayComplete, setDayComplete] = useState(false);
   const [showMissedSetNumbers, setShowMissedSetNumbers] = useState(false);
   const [showMaxoutNumbers, setShowMaxoutNumbers] = useState(false);
+  const [showTimerModal, setShowTimerModal] = useState(false);
 
   return (
     <section className={styles.pyramidSectionContainer}>
@@ -28,58 +31,76 @@ const Pyramid = () => {
         <DayComplete />
       ) : (
         <>
+          <h3 className={styles.doRepsText}>
+            {missed ? (
+              `How many did you do?`
+            ) : showMaxoutNumbers ? (
+              `MAX OUT!`
+            ) : (
+            `DO ${completedReps + 1} ${isSingular(completedReps + 1) ? 'REP' : 'REPS'}`
+            )}
+          </h3>
 
+          <div className={ styles.actionButtonContainer }>
+            {repsArray.length > 0 && !missed && !showMaxoutNumbers && (
+              <MissSetButton
+                showTimerModalState={showTimerModal}
+                onMissed={setMissed}
+              />
+            )}
 
-      {missed ? (
-        <h3 className={styles.doRepsText}>How many did you do?</h3>
-      ) : showMaxoutNumbers ? (
-        <h3 className={styles.doRepsText}>MAX OUT!</h3>
-      ) : (
-        <h3 className={styles.doRepsText}>DO {reps} {isSingular(reps) ? 'REP' : 'REPS'}</h3>
-          )}
-      <div className={ styles.actionButtonContainer }>
-        {repsArray.length > 0 && !missed && !showMaxoutNumbers && (
-          <MissSetButton onMissed={setMissed} />
-        )}
-        {missed ? (
-            <div className={styles.missedSetNumberContainer}>
-              {repsArray.map((reps, i) => {
-                return (
-                  <NumberedMissRepButton
-                    key={`${i}-${reps}`}
-                    repCount={reps}
-                    repsArrayState={repsArray}
-                    setStateForRepsArray={setRepsArray}
-                    setStateForReps={setReps}
-                    onMissed={setMissed}
-                    setStateForMaxNumbers={setShowMaxoutNumbers}
-                  />
-                )
-              })}
-            </div>
-        ) : showMaxoutNumbers ? (
-          <div className={styles.maxoutRepNumberContainer}>
-            {repsArray.map((reps, i) => {
-              return (
-                <MaxoutNumberButton
-                  key={`${i}-${reps}`}
-                  repCount={reps}
-                  repsArrayState={repsArray}
-                  setStateForRepsArray={setRepsArray}
-                  setStateForDayComplete={setDayComplete}
-                />
-              )
-            })}
+            {missed ? (
+                <div className={styles.missedSetNumberContainer}>
+                  {repsArray.map((reps, i) => {
+                    return (
+                      <NumberedMissRepButton
+                        key={`${i}-${reps}`}
+                        repCount={reps}
+                        repsArrayState={repsArray}
+                        setStateForRepsArray={setRepsArray}
+                        setStateForReps={setCompletedReps}
+                        onMissed={setMissed}
+                        setStateForMaxNumbers={setShowMaxoutNumbers}
+                        setStateForShowTimerModal={setShowTimerModal}
+                        showTimerModalState={showTimerModal}
+                      />
+                    )
+                  })}
+                </div>
+            ) : showMaxoutNumbers ? (
+              <div className={styles.maxoutRepNumberContainer}>
+                {repsArray.map((reps, i) => {
+                  return (
+                    <MaxoutNumberButton
+                      key={`${i}-${reps}`}
+                      repCount={reps}
+                      repsArrayState={repsArray}
+                      setStateForRepsArray={setRepsArray}
+                      setStateForDayComplete={setDayComplete}
+                    />
+                  )
+                })}
+              </div>
+            ) : (
+            <RepsCompleteButton
+              repsState={completedReps}
+              repsArrayState={repsArray}
+              setStateForReps={setCompletedReps}
+              setStateForRepsArray={setRepsArray}
+              setStateForShowTimerModal={setShowTimerModal}
+              showTimerModalState={showTimerModal}
+            />
+            )}
           </div>
-        ) : (
-        <RepsCompleteButton
-          repsState={reps}
-          repsArrayState={repsArray}
-          setStateForReps={setReps}
-          setStateForRepsArray={setRepsArray}
-        />
-        )}
-      </div>
+          {showTimerModal && createPortal(
+            <TimerModal
+              recoveryTime={10 * completedReps}
+              onClose={() => setShowTimerModal(false)}
+              setStateForShowTimerModal={setShowTimerModal}
+            />,
+            document.body
+          )}
+
         </>
       )}
     </section>

--- a/src/app/components/program/pyramid/RepsCompleteButton.tsx
+++ b/src/app/components/program/pyramid/RepsCompleteButton.tsx
@@ -1,56 +1,48 @@
-import {Dispatch, SetStateAction, useState} from "react";
-import styles from './RepsCompleteButton.module.css';
+import {Dispatch, SetStateAction} from "react";
+import styles from './ActionButton.module.css';
 import {checkMarkButtonEmoji} from "@/emojis";
-import {createPortal} from "react-dom";
-import TimerModal from "../TimerModal";
 
 interface RepsCompleteButtonProps {
   repsState: number;
   repsArrayState: number[];
+  showTimerModalState: boolean;
   setStateForReps: Dispatch<SetStateAction<number>>;
   setStateForRepsArray: Dispatch<SetStateAction<number[]>>;
+  setStateForShowTimerModal: Dispatch<SetStateAction<boolean>>;
 }
 
 const RepsCompleteButton = ({
   repsState,
   repsArrayState,
   setStateForReps,
-  setStateForRepsArray
+  showTimerModalState,
+  setStateForRepsArray,
+  setStateForShowTimerModal
 }: RepsCompleteButtonProps) => {
 
-  const [showTimerModal, setShowTimerModal] = useState(false);
-  const [recoveryTime, setRecoveryTime] = useState(0);
-
   function handleClick() {
-    setRecoveryTime(10 * repsState);
+    const pyramidBrickNumber = repsState + 1;
+
     setStateForRepsArray(
       [
         ...repsArrayState,
-        repsState
+        pyramidBrickNumber
       ]
     );
+
     setStateForReps(repsState => repsState + 1);
-    setShowTimerModal(true);
+
+    setStateForShowTimerModal(true);
   }
 
   return (
-    <>
-      <button
-        className={styles.completeButton}
-        onClick={handleClick}
-        disabled={showTimerModal}
-      >
-        {checkMarkButtonEmoji}
-      </button>
-      {showTimerModal && createPortal(
-      <TimerModal
-        onClose={() => setShowTimerModal(false)}
-        recoveryTime={recoveryTime}
-        setStateForShowTimerModal={setShowTimerModal}
-      />,
-      document.body
-      )}
-    </>
+    <button
+      className={styles.pyramidActionButton}
+      onClick={handleClick}
+      disabled={showTimerModalState}
+    >
+      {checkMarkButtonEmoji}
+    </button>
   )
 };
 

--- a/src/app/components/program/threeTrainingSetsThreeGrips/SetInfo.tsx
+++ b/src/app/components/program/threeTrainingSetsThreeGrips/SetInfo.tsx
@@ -71,6 +71,7 @@ const SetInfo = ({
         <button
           className={styles.actionButton}
           onClick={handleMiss}
+          disabled={showTimerModal}
         >
           {crossMarkButtonEmoji}
         </button>


### PR DESCRIPTION
hitting enter now triggers the timer on day-one. Upon further investigation, the other days do not need to have enter work on input because the input of reps leads to the use of a button. Also moved the timer around for day-two.
Also disabled buttons and inputs while the timer modal is visible.

close #3