### PR TITLE
Add sitemap.xml for Google Search Console

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,18 @@
+import { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: "https://repyourself.app",
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 1,
+    },
+    {
+      url: "https://repyourself.app/privacy",
+      lastModified: new Date(),
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
+  ];
+}


### PR DESCRIPTION
Serves /sitemap.xml via Next.js built-in sitemap support. Includes the landing page (priority 1) and privacy policy (priority 0.3). App pages are excluded — they are UI, not indexable content.