### PR TITLE
fix(seo): align h1 with title tag to prevent Google title rewriting

### DIFF
--- a/src/app/lib/seo.ts
+++ b/src/app/lib/seo.ts
@@ -6,7 +6,7 @@ export const defaultMetadata: Metadata = {
     canonical: "/",
   },
   title: {
-    default: "Rep Yourself — The Armstrong Pull-up Program App",
+    default: "Rep Yourself • The Armstrong Pull-up Program App",
     template: "%s | Rep Yourself",
   },
   description:

--- a/src/components/landing/Hero.module.css
+++ b/src/components/landing/Hero.module.css
@@ -30,6 +30,13 @@
   justify-content: center;
 }
 
+.h1Subtitle {
+  display: block;
+  font-size: 0.5em;
+  font-weight: 400;
+  opacity: 0.75;
+}
+
 .button {
   padding: 0.875rem 1rem;
   place-self: center;

--- a/src/components/landing/Hero.tsx
+++ b/src/components/landing/Hero.tsx
@@ -9,7 +9,12 @@ const Hero = () => {
     <section id="home" className={styles.hero}>
       <LandingNavbar />
       <div className={styles.heroLeft}>
-        <h1 style={nunito.style}>Rep Yourself</h1>
+        <h1 style={nunito.style}>
+          Rep Yourself
+          <span className={styles.h1Subtitle}>
+            The Armstrong Pull-up Program App
+          </span>
+        </h1>
         <h2 style={nunito.style}>
           Master pull-ups with the Armstrong Pull-up Program.
         </h2>

--- a/tests/pom/mixins/dayOne.ts
+++ b/tests/pom/mixins/dayOne.ts
@@ -43,6 +43,7 @@ export function CreateDayOnePOM<
     async startUserFlow() {
       await this.page.goto(`/`);
       await this.getStartedLink.click();
+      await this.dayOneLink.waitFor({ state: "visible" });
       await this.dayOneLink.click();
     }
   };


### PR DESCRIPTION
Google was overriding the <title> with "repyourself.app" because the <h1> only said "Rep Yourself", matching the domain. Adding the program name to the h1 as a styled subtitle span gives Google consistent signals across h1 and title, without altering the visual brand hierarchy.