### PR TITLE
feat(seo): add SoftwareApplication+WebApplication JSON-LD to homepage

### DIFF
--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -113,9 +113,34 @@ const howToSchema = {
   ],
 };
 
+const appSchema = {
+  "@context": "https://schema.org",
+  "@type": ["SoftwareApplication", "WebApplication"],
+  name: "Rep Yourself | Armstrong Pull-up Program",
+  operatingSystem: "Web, Android, iOS",
+  applicationCategory: "HealthApplication",
+  description:
+    "Free Armstrong Pull-up Program app and tracker. Follow Major Armstrong's 5-day pull-up routine, time your rest automatically, and track your progress offline.",
+  url: "https://repyourself.app",
+  offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+  // aggregateRating: {
+  //   "@type": "AggregateRating",
+  //   "ratingValue": "X.X",
+  //   "ratingCount": "XX",
+  // },
+  // Add aggregateRating above once you have verified ratings from real users.
+  // Fabricated ratings violate Google's structured data guidelines and can
+  // result in a manual penalty. Only add this when you have genuine reviews
+  // collected through a verifiable platform.
+};
+
 export default function Home() {
   return (
     <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(appSchema) }}
+      />
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,20 +4,6 @@ import { defaultMetadata } from "@/app/lib/seo";
 
 export const metadata: Metadata = defaultMetadata;
 
-const webAppSchema = {
-  "@context": "https://schema.org",
-  "@type": "WebApplication",
-  name: "Rep Yourself",
-  url: "https://repyourself.app",
-  description:
-    "Rep Yourself — The Armstrong Pull-up Program App. Track pullups, follow the 5-day routine, and master calisthenics training.",
-  applicationCategory: "HealthApplication",
-  operatingSystem: "Any",
-  offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
-  featureList:
-    "Pull-up workout tracking, Progress visualization, Offline PWA, Built-in rest timer, 5-day routine",
-};
-
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -31,10 +17,6 @@ export default function RootLayout({
           async
           src="//gc.zgo.at/count.js"
         ></script>
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(webAppSchema) }}
-        />
         {children}
       </body>
     </html>


### PR DESCRIPTION
Replaces the generic WebApplication schema that was incorrectly injected on every page via the root layout. The new co-typed schema lives only on the homepage and includes a commented placeholder for aggregateRating to be added once verified ratings exist.