### PR TITLE
fix(pwa): update manifest name, description, and bump version to 3

### DIFF
--- a/src/app/manifest.json
+++ b/src/app/manifest.json
@@ -1,10 +1,10 @@
 {
-  "version": "2",
+  "version": "3",
   "manifest_version": 2,
   "id": "/program",
-  "name": "Rep Yourself",
+  "name": "Rep Yourself | Armstrong Pull-up Program",
   "short_name": "Rep Yourself",
-  "description": "Rep Yourself — master pull-ups with the Armstrong Pull-up Program. Free, offline-capable PWA.",
+  "description": "Free Armstrong Pull-up Program app and tracker. Follow Major Armstrong's 5-day pull-up routine. Offline-capable PWA.",
   "start_url": "/program?utm_source=homescreen",
   "scope": "/",
   "display": "standalone",


### PR DESCRIPTION
Updates name to 'Rep Yourself | Armstrong Pull-up Program', refreshes description copy, and increments version to 3 so installed PWAs detect the update (version 2 was taken by the start_url utm_source change).