### PR TITLE
feat(contact): add support/privacy/howto email touchpoints

### DIFF
--- a/src/app/(app)/program/error.tsx
+++ b/src/app/(app)/program/error.tsx
@@ -2,6 +2,7 @@
 
 import { nunito, ptSans } from "@/fonts";
 import { useEffect } from "react";
+import Link from "next/link";
 import styles from "./error.module.css";
 
 export default function Error({
@@ -28,6 +29,13 @@ export default function Error({
       >
         Try again!
       </button>
+      <p style={ptSans.style}>
+        Lost your progress? Email us at{" "}
+        <Link href={"mailto:support@repyourself.app"}>
+          support@repyourself.app
+        </Link>{" "}
+        and we&apos;ll help you sort it out.
+      </p>
     </main>
   );
 }

--- a/src/components/landing/Footer.tsx
+++ b/src/components/landing/Footer.tsx
@@ -24,11 +24,14 @@ const Footer = () => {
           <strong>PRIVACY POLICY</strong>
         </Link>
         <Link
-          href={"https://www.suityourself.app/"}
+          href={"https://suityourself.app"}
           target="_blank"
           style={nunito.style}
         >
           <strong>SUIT YOURSELF</strong>
+        </Link>
+        <Link href={"mailto:support@repyourself.app"} style={nunito.style}>
+          <strong>SUPPORT</strong>
         </Link>
       </section>
       <section className={styles.socials}>

--- a/src/components/privacy/PrivacyPolicy.tsx
+++ b/src/components/privacy/PrivacyPolicy.tsx
@@ -6,7 +6,7 @@ const lastUpdatedDate = "December 8th, 2025";
 const mainGooglePrivacyPolicy = "https://policies.google.com/privacy";
 const otherGooglePrivacyPolicy =
   "https://policies.google.com/technologies/partner-sites";
-const emailAddress = "repyourself.privacy@gmail.com";
+const emailAddress = "privacy@repyourself.app";
 
 export default function PrivacyPolicy() {
   return (
@@ -257,10 +257,11 @@ export default function PrivacyPolicy() {
           <section id="contact">
             <h6>Contact</h6>
             <p>
-              If you have any questions or suggestions about the Privacy Policy,
-              do not hesitate to contact me.
+              If you have any questions, suggestions, or requests regarding your
+              data — including access, correction, or deletion requests — do not
+              hesitate to contact us at{" "}
+              <Link href={`mailto:${emailAddress}`}>{emailAddress}</Link>.
             </p>
-            <p>{emailAddress}</p>
           </section>
         </li>
       </ol>

--- a/src/components/program/DayComplete.tsx
+++ b/src/components/program/DayComplete.tsx
@@ -16,6 +16,7 @@ import { track } from "@/lib/track";
 import { nunito } from "@/fonts";
 import { CircleCheckBigIcon, SaveIcon, ThumbsUpIcon } from "lucide-react";
 import Link from "next/link";
+import { Fragment } from "react";
 import {
   DAY_COMPLETE_MESSAGES,
   THUMBS_UP_ICON_MESSAGE,
@@ -92,11 +93,18 @@ const DayComplete = ({ dayData, setStateForSavedDay }: DayCompleteProps) => {
         <TotalReps sets={dayData.sets} />
       </div>
       <h3 className={styles.message} style={nunito.style}>
-        {saveError
-          ? "Save failed — please try again"
-          : isDataSaved
-            ? DAY_COMPLETE_MESSAGES[0]
-            : DAY_COMPLETE_MESSAGES[1]}
+        {saveError ? (
+          <Fragment>
+            Save failed — please try again, or email{" "}
+            <Link href={"mailto:support@repyourself.app"}>
+              support@repyourself.app
+            </Link>
+          </Fragment>
+        ) : isDataSaved ? (
+          DAY_COMPLETE_MESSAGES[0]
+        ) : (
+          DAY_COMPLETE_MESSAGES[1]
+        )}
       </h3>
       <div className={styles.takeAction} style={nunito.style}>
         {isDataSaved ? (

--- a/src/components/program/DayHeadings.tsx
+++ b/src/components/program/DayHeadings.tsx
@@ -3,6 +3,7 @@ import styles from "./DayHeadings.module.css";
 import { DAYS } from "@/const";
 import { nunito } from "@/fonts";
 import DailyHintButton from "@/components/program/DailyHintButton";
+import HowToLink from "@/components/program/HowToLink";
 
 interface DayHeadingsProps {
   dayNumber: TDayNumber;
@@ -24,6 +25,7 @@ const DayHeadings = ({ dayNumber, mostDifficultDay }: DayHeadingsProps) => {
             {DAYS.filter((day) => day.number === mostDifficultDay)[0].heading3}
           </h3>
           <DailyHintButton dayNumber={mostDifficultDay} />
+          <HowToLink dayNumber={mostDifficultDay} />
         </div>
       ) : (
         <div className={styles.headingsContainer}>
@@ -37,6 +39,7 @@ const DayHeadings = ({ dayNumber, mostDifficultDay }: DayHeadingsProps) => {
             {DAYS.filter((day) => day.number === dayNumber)[0].heading3}
           </h3>
           <DailyHintButton dayNumber={dayNumber} />
+          <HowToLink dayNumber={dayNumber} />
         </div>
       )}
     </>

--- a/src/components/program/HowToLink.module.css
+++ b/src/components/program/HowToLink.module.css
@@ -1,0 +1,12 @@
+.link {
+  height: 1.5rem;
+  width: 1.5rem;
+  display: block;
+  place-self: center;
+}
+
+.icon {
+  height: 100%;
+  width: 100%;
+  color: #aaa;
+}

--- a/src/components/program/HowToLink.tsx
+++ b/src/components/program/HowToLink.tsx
@@ -1,0 +1,30 @@
+import { MailQuestionMarkIcon } from "lucide-react";
+import Link from "next/link";
+import styles from "./HowToLink.module.css";
+
+interface HowToLinkProps {
+  dayNumber: number;
+}
+
+const HOW_TO_SUBJECTS: Record<number, string> = {
+  2: "Question about Day 2 pyramid",
+  3: "Question about Day 3 grip rotation",
+};
+
+const HowToLink = ({ dayNumber }: HowToLinkProps) => {
+  const subject = HOW_TO_SUBJECTS[dayNumber];
+
+  if (!subject) return null;
+
+  return (
+    <Link
+      href={`mailto:howto@repyourself.app?subject=${encodeURIComponent(subject)}`}
+      title="How does this work? Email us"
+      className={styles.link}
+    >
+      <MailQuestionMarkIcon className={styles.icon} />
+    </Link>
+  );
+};
+
+export default HowToLink;


### PR DESCRIPTION
- Add support@repyourself.app to the footer, the /program crash boundary, and the DayComplete save-failure message (the moment a user has actually lost workout progress).
- Update the /privacy contact section to privacy@repyourself.app, explicit about data access/correction/deletion requests.
- Add a small mail-question icon near Day 2/3 (and Day 5 when it uses the pyramid or grip-rotation mechanic) that opens a pre-filled mailto to howto@repyourself.app.
- Fix suityourself.app footer link to drop the incorrect www subdomain.