### PR TITLE
Show pullup animation while program day loads instead of a blank gap

### DIFF
--- a/src/components/program/Program.module.css
+++ b/src/components/program/Program.module.css
@@ -13,3 +13,10 @@
   grid-template-rows: 2.65rem;
   gap: 0.325rem;
 }
+
+.loadingIndicator {
+  grid-column: 1 / -1;
+  height: 2.65rem;
+  width: 2.65rem;
+  place-self: center;
+}

--- a/src/components/program/Program.tsx
+++ b/src/components/program/Program.tsx
@@ -9,6 +9,7 @@ import { getLastCompletedDay } from "@/indexedDBActions";
 import { dbInitialized } from "@/data/indexedDB";
 import { nunito } from "@/fonts";
 import SkipDayButton from "./SkipDayButton";
+import PullupSVG from "../PullupSVG";
 import { Dispatch, SetStateAction } from "react";
 
 const heading = "TODAY'S WORKOUT";
@@ -19,6 +20,7 @@ interface ProgramProps {
 
 const Program = ({ setStateForUpdatePastWorkouts }: ProgramProps) => {
   const [programDayNumber, setProgramDayNumber] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     let isMounted = true;
@@ -30,6 +32,7 @@ const Program = ({ setStateForUpdatePastWorkouts }: ProgramProps) => {
     const fallbackTimer = setTimeout(() => {
       if (isMounted) {
         setProgramDayNumber(1);
+        setIsLoading(false);
         setStateForUpdatePastWorkouts(1);
       }
     }, 3000);
@@ -40,6 +43,7 @@ const Program = ({ setStateForUpdatePastWorkouts }: ProgramProps) => {
         clearTimeout(fallbackTimer);
         if (isMounted) {
           setProgramDayNumber(value + 1);
+          setIsLoading(false);
           setStateForUpdatePastWorkouts(value + 1);
         }
       })
@@ -48,6 +52,7 @@ const Program = ({ setStateForUpdatePastWorkouts }: ProgramProps) => {
         clearTimeout(fallbackTimer);
         if (isMounted) {
           setProgramDayNumber(1);
+          setIsLoading(false);
           setStateForUpdatePastWorkouts(1);
         }
       });
@@ -58,29 +63,35 @@ const Program = ({ setStateForUpdatePastWorkouts }: ProgramProps) => {
     };
   }, [setStateForUpdatePastWorkouts]);
 
-  const currentProgramDay = DAYS.filter(
-    (day) => day.number === programDayNumber,
-  );
+  const currentProgramDay = DAYS.find((day) => day.number === programDayNumber);
 
   return (
     <section className={styles.sectionContainer}>
       <h2 style={nunito.style}>{heading}</h2>
-      {currentProgramDay.map((day) => {
-        return (
-          <section className={styles.workoutDecisionSection} key={day.name}>
+      <section className={styles.workoutDecisionSection}>
+        {isLoading || !currentProgramDay ? (
+          <div
+            className={styles.loadingIndicator}
+            role="status"
+            aria-label="Loading your workout"
+          >
+            <PullupSVG />
+          </div>
+        ) : (
+          <>
             <SkipDayButton
-              dayNumber={day.number}
+              dayNumber={currentProgramDay.number}
               setStateForProgramDayNumber={setProgramDayNumber}
               setStateForUpdatePastWorkouts={setStateForUpdatePastWorkouts}
             />
             <PageLink
-              path={day.path}
-              label={day.label}
+              path={currentProgramDay.path}
+              label={currentProgramDay.label}
               onClick={() => track("workout-start")}
             />
-          </section>
-        );
-      })}
+          </>
+        )}
+      </section>
     </section>
   );
 };

--- a/tests/pom/program-page.ts
+++ b/tests/pom/program-page.ts
@@ -11,6 +11,7 @@ export class ProgramPage {
   readonly dayLink: Locator;
   readonly todaysWorkoutHeader: Locator;
   readonly skipButton: Locator;
+  readonly loadingIndicator: Locator;
   readonly resetButton: Locator;
   readonly resetModal: Locator;
   readonly resetModalCancelButton: Locator;
@@ -36,14 +37,21 @@ export class ProgramPage {
     // This is the get started link from the landing page
     this.getStartedLink = page.getByRole("link", { name: "GET STARTED" });
     this.skipButton = page.getByRole("button", { name: "SKIP" });
+    this.loadingIndicator = page.getByRole("status", {
+      name: "Loading your workout",
+    });
     this.resetButton = page.locator("#reset-program-button");
     this.resetModal = page.locator("#reset-program-modal");
     this.resetModalCancelButton = page.locator("#reset-modal-cancel-button");
     this.resetModalConfirmButton = page.locator("#reset-modal-confirm-button");
     this.downloadButton = page.locator("#migrate-data-button");
     this.downloadModal = page.locator("#download-data-modal");
-    this.downloadModalCancelButton = page.locator("#download-modal-cancel-button");
-    this.downloadModalConfirmButton = page.locator("#download-modal-confirm-button");
+    this.downloadModalCancelButton = page.locator(
+      "#download-modal-cancel-button",
+    );
+    this.downloadModalConfirmButton = page.locator(
+      "#download-modal-confirm-button",
+    );
   }
 
   async goto() {

--- a/tests/programPageDbFallback.spec.ts
+++ b/tests/programPageDbFallback.spec.ts
@@ -27,11 +27,13 @@ test("SKIP and DAY 1 buttons still render when IndexedDB never responds", async 
 
   // GET STARTED heading renders unconditionally, unlike the day buttons.
   await expect(programPage.getStartedHeader).toBeVisible();
+  await expect(programPage.loadingIndicator).toBeVisible();
   await expect(programPage.dayLink).not.toBeVisible();
   await expect(programPage.skipButton).not.toBeVisible();
 
   await page.clock.fastForward(3000);
 
+  await expect(programPage.loadingIndicator).not.toBeVisible();
   await expect(programPage.dayLink).toBeVisible();
   await expect(programPage.dayLink).toHaveText("DAY 1");
   await expect(programPage.skipButton).toBeVisible();


### PR DESCRIPTION
Previously the SKIP/DAY buttons only mounted once IndexedDB resolved, so the box they occupy didn't exist at first paint and content shifted into place when it did. The buttons' container now always renders at its existing fixed size, showing the looping PullupSVG illustration in its place until the day is known, so nothing pops in or shifts.


Claude-Session: https://claude.ai/code/session_01Mn5fqwKdxteuZrdSTe1FWV