### PR TITLE
Warn before losing in-progress workout data on back navigation

### DIFF
--- a/src/components/program/ExitWorkoutModal.module.css
+++ b/src/components/program/ExitWorkoutModal.module.css
@@ -1,0 +1,96 @@
+.backdrop {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  position: fixed;
+  z-index: 2;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.8);
+  animation: fadeIn 0.2s forwards ease-in-out;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.dialog {
+  background-color: #fefefe;
+  color: #111;
+  padding: 2rem;
+  border: 1px solid #888;
+  border-radius: 0.5rem;
+  width: min(80%, 28rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  align-items: center;
+  text-align: center;
+}
+
+.icon {
+  color: #c0392b;
+  height: 2.5rem;
+  width: 2.5rem;
+}
+
+.heading {
+  margin: 0;
+  color: #c0392b;
+}
+
+.message {
+  margin: 0;
+  line-height: 1.5;
+  color: #444;
+}
+
+.actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  width: 100%;
+}
+
+.cancelButton {
+  flex: 1;
+  min-height: 2.75rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid #999;
+  border-radius: 0.4rem;
+  background: transparent;
+  color: #444;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.cancelButton:hover,
+.cancelButton:focus {
+  background: #f0f0f0;
+}
+
+.leaveButton {
+  flex: 1;
+  min-height: 2.75rem;
+  padding: 0.75rem 1rem;
+  border: none;
+  border-radius: 0.4rem;
+  background: #c0392b;
+  color: #fff;
+  font-size: 1rem;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.leaveButton:hover,
+.leaveButton:focus {
+  background: #a93226;
+}

--- a/src/components/program/ExitWorkoutModal.tsx
+++ b/src/components/program/ExitWorkoutModal.tsx
@@ -1,0 +1,68 @@
+import { useEffect } from "react";
+import { TriangleAlertIcon } from "lucide-react";
+import { nunito, ptSans } from "@/fonts";
+import styles from "./ExitWorkoutModal.module.css";
+
+interface ExitWorkoutModalProps {
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+const ExitWorkoutModal = ({ onClose, onConfirm }: ExitWorkoutModalProps) => {
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  return (
+    <div
+      id="exit-workout-modal"
+      className={styles.backdrop}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="exit-workout-modal-heading"
+    >
+      <div id="exit-workout-modal-content" className={styles.dialog}>
+        <TriangleAlertIcon className={styles.icon} />
+        <h2
+          id="exit-workout-modal-heading"
+          style={nunito.style}
+          className={styles.heading}
+        >
+          Leave Workout?
+        </h2>
+        <p className={styles.message} style={ptSans.style}>
+          Your progress on this workout hasn&apos;t been saved yet. If you leave
+          now, it will be lost.
+        </p>
+        <div className={styles.actions}>
+          <button
+            id="exit-workout-modal-cancel-button"
+            type="button"
+            className={styles.cancelButton}
+            style={nunito.style}
+            onClick={onClose}
+            aria-label="Cancel leaving workout"
+          >
+            Cancel
+          </button>
+          <button
+            id="exit-workout-modal-confirm-button"
+            type="button"
+            className={styles.leaveButton}
+            style={nunito.style}
+            onClick={onConfirm}
+            aria-label="Confirm leave workout"
+          >
+            Leave
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ExitWorkoutModal;

--- a/src/components/program/fiveMaxEffortSets/FiveMaxEffortSets.tsx
+++ b/src/components/program/fiveMaxEffortSets/FiveMaxEffortSets.tsx
@@ -9,6 +9,8 @@ import SetsTable from "@/components/program/fiveMaxEffortSets/SetsTable";
 import { createPortal } from "react-dom";
 import TimerModal from "@/components/program/TimerModal";
 import DayComplete from "@/components/program/DayComplete";
+import ExitWorkoutModal from "@/components/program/ExitWorkoutModal";
+import { useConfirmExitOnBack } from "@/hooks/useConfirmExitOnBack";
 import { TDayNumber } from "@/definitions";
 import DayProgessBar from "../DayProgressBar";
 
@@ -27,6 +29,9 @@ const FiveMaxEffortSets = ({ dayNumber }: FiveMaxEffortSetsProps) => {
   const [savedDay, setSavedDay] = useState(false);
 
   const dayComplete = repsArray.length === 5;
+  const hasProgress = repsArray.length > 0 && !savedDay;
+  const { showExitModal, cancelExit, confirmExit } =
+    useConfirmExitOnBack(hasProgress);
 
   return (
     <section className={styles.repInfoSection}>
@@ -87,6 +92,9 @@ const FiveMaxEffortSets = ({ dayNumber }: FiveMaxEffortSetsProps) => {
               document.body,
             )}
         </>
+      )}
+      {showExitModal && (
+        <ExitWorkoutModal onClose={cancelExit} onConfirm={confirmExit} />
       )}
     </section>
   );

--- a/src/components/program/maxTrainingSets/MaxTrainingSets.tsx
+++ b/src/components/program/maxTrainingSets/MaxTrainingSets.tsx
@@ -4,6 +4,8 @@ import { useState } from "react";
 import TrainingSetRepsInput from "@/components/program/TrainingSetRepsInput";
 import MaxTrainingSetsDisplay from "@/components/program/maxTrainingSets/MaxTrainingSetsDisplay";
 import DayComplete from "@/components/program/DayComplete";
+import ExitWorkoutModal from "@/components/program/ExitWorkoutModal";
+import { useConfirmExitOnBack } from "@/hooks/useConfirmExitOnBack";
 import { TDayNumber } from "@/definitions";
 
 interface MaxTrainingSetsProps {
@@ -18,6 +20,11 @@ const MaxTrainingSets = ({ dayNumber }: MaxTrainingSetsProps) => {
     initialCompletedTrainingSets,
   );
   const [savedDay, setSavedDay] = useState(false);
+
+  const hasProgress =
+    (trainingSetReps > 0 || completedTrainingSets.length > 0) && !savedDay;
+  const { showExitModal, cancelExit, confirmExit } =
+    useConfirmExitOnBack(hasProgress);
 
   return (
     <section>
@@ -42,6 +49,9 @@ const MaxTrainingSets = ({ dayNumber }: MaxTrainingSetsProps) => {
           updateCompletedTrainingSets={setCompletedTrainingSets}
           updateDayComplete={setDayComplete}
         />
+      )}
+      {showExitModal && (
+        <ExitWorkoutModal onClose={cancelExit} onConfirm={confirmExit} />
       )}
     </section>
   );

--- a/src/components/program/pyramid/Pyramid.tsx
+++ b/src/components/program/pyramid/Pyramid.tsx
@@ -10,6 +10,8 @@ import PyramidDisplay from "@/components/program/pyramid/PyramidDisplay";
 import NumberedMissRepButton from "@/components/program/NumberedMissRepButton";
 import TimerModal from "@/components/program/TimerModal";
 import MissSetButton from "@/components/program/MissSetButton";
+import ExitWorkoutModal from "@/components/program/ExitWorkoutModal";
+import { useConfirmExitOnBack } from "@/hooks/useConfirmExitOnBack";
 import { createPortal } from "react-dom";
 import { TDayAbbreviation, TDayNumber } from "@/definitions";
 import { nunito } from "@/fonts";
@@ -29,6 +31,10 @@ const Pyramid = ({ dayNumber }: PyramidProps) => {
   const [showMaxoutNumbers, setShowMaxoutNumbers] = useState(false);
   const [showTimerModal, setShowTimerModal] = useState(false);
   const [savedDay, setSavedDay] = useState(false);
+
+  const hasProgress = repsArray.length > 0 && !savedDay;
+  const { showExitModal, cancelExit, confirmExit } =
+    useConfirmExitOnBack(hasProgress);
 
   return (
     <section className={styles.pyramidSectionContainer}>
@@ -126,6 +132,9 @@ const Pyramid = ({ dayNumber }: PyramidProps) => {
               document.body,
             )}
         </>
+      )}
+      {showExitModal && (
+        <ExitWorkoutModal onClose={cancelExit} onConfirm={confirmExit} />
       )}
     </section>
   );

--- a/src/components/program/threeTrainingSetsThreeGrips/ThreeTrainingSetsThreeGrips.tsx
+++ b/src/components/program/threeTrainingSetsThreeGrips/ThreeTrainingSetsThreeGrips.tsx
@@ -5,6 +5,8 @@ import TrainingSetRepsInput from "@/components/program/TrainingSetRepsInput";
 import GripSelector from "@/components/program/threeTrainingSetsThreeGrips/GripSelector";
 import SetInfo from "@/components/program/threeTrainingSetsThreeGrips/SetInfo";
 import DayComplete from "@/components/program/DayComplete";
+import ExitWorkoutModal from "@/components/program/ExitWorkoutModal";
+import { useConfirmExitOnBack } from "@/hooks/useConfirmExitOnBack";
 import { TDayNumber, TGrip } from "@/app/lib/definitions";
 
 interface ThreeTrainingSetsThreeGripsProps {
@@ -25,6 +27,10 @@ const ThreeTrainingSetsThreeGrips = ({
   const [savedDay, setSavedDay] = useState(false);
 
   const dayComplete = completedGrips.length === 3;
+  const hasProgress =
+    (trainingSetReps > 0 || completedGrips.length > 0) && !savedDay;
+  const { showExitModal, cancelExit, confirmExit } =
+    useConfirmExitOnBack(hasProgress);
 
   return (
     <section>
@@ -57,6 +63,9 @@ const ThreeTrainingSetsThreeGrips = ({
           updateCurrentGrip={setCurrentGrip}
           updateCompletedGrips={setCompletedGrips}
         />
+      )}
+      {showExitModal && (
+        <ExitWorkoutModal onClose={cancelExit} onConfirm={confirmExit} />
       )}
     </section>
   );

--- a/src/hooks/useConfirmExitOnBack.ts
+++ b/src/hooks/useConfirmExitOnBack.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+
+export function useConfirmExitOnBack(hasProgress: boolean) {
+  const router = useRouter();
+  const guardedRef = useRef(false);
+  const [showExitModal, setShowExitModal] = useState(false);
+
+  useEffect(() => {
+    if (hasProgress && !guardedRef.current) {
+      guardedRef.current = true;
+      window.history.pushState({ workoutExitGuard: true }, "");
+    }
+    if (!hasProgress && guardedRef.current) {
+      guardedRef.current = false;
+      setShowExitModal(false);
+    }
+  }, [hasProgress]);
+
+  useEffect(() => {
+    // If a review modal (src/components/program/Modal.tsx) is ever opened from
+    // inside an active workout, its Escape/close handler calls router.back(),
+    // which this listener would intercept and misreport as a workout-exit
+    // attempt. No current code path mounts both at once, so this is safe today.
+    function handlePopState() {
+      if (!guardedRef.current) return;
+      window.history.pushState({ workoutExitGuard: true }, "");
+      setShowExitModal(true);
+    }
+    window.addEventListener("popstate", handlePopState);
+    return () => window.removeEventListener("popstate", handlePopState);
+  }, []);
+
+  const cancelExit = useCallback(() => setShowExitModal(false), []);
+
+  const confirmExit = useCallback(() => {
+    guardedRef.current = false;
+    setShowExitModal(false);
+    router.replace("/program");
+  }, [router]);
+
+  return { showExitModal, cancelExit, confirmExit };
+}

--- a/tests/exitWorkoutGuard.spec.ts
+++ b/tests/exitWorkoutGuard.spec.ts
@@ -1,0 +1,109 @@
+import { DayOneWorkoutPage } from "./pom";
+import { test, expect } from "@playwright/test";
+
+async function logOneSet(dayOnePage: InstanceType<typeof DayOneWorkoutPage>) {
+  await dayOnePage.pressPlusIcon(3);
+  await dayOnePage.pressCompleteSetButton();
+  await dayOnePage.timerModalCloseButton.waitFor({ state: "visible" });
+  await dayOnePage.closeTimerModal();
+}
+
+test("no progress logged: back navigation is not intercepted", async ({
+  page,
+}) => {
+  const dayOnePage = new DayOneWorkoutPage(page, 1);
+  await dayOnePage.startUserFlow();
+  await expect(dayOnePage.dayHeading).toBeVisible();
+
+  await page.goBack();
+
+  await expect(dayOnePage.exitWorkoutModal).not.toBeVisible();
+  await expect(dayOnePage.dayHeading).not.toBeVisible();
+});
+
+test("progress logged: back navigation shows the exit warning and stays on the page", async ({
+  page,
+}) => {
+  const dayOnePage = new DayOneWorkoutPage(page, 1);
+  await dayOnePage.startUserFlow();
+  await logOneSet(dayOnePage);
+
+  await page.goBack();
+
+  await expect(dayOnePage.exitWorkoutModal).toBeVisible();
+  await expect(dayOnePage.dayHeading).toBeVisible();
+  await expect(dayOnePage.repInputLabel).toHaveText("SET 2 REPS");
+});
+
+test("cancelling the exit warning keeps in-progress data intact", async ({
+  page,
+}) => {
+  const dayOnePage = new DayOneWorkoutPage(page, 1);
+  await dayOnePage.startUserFlow();
+  await logOneSet(dayOnePage);
+  await page.goBack();
+  await expect(dayOnePage.exitWorkoutModal).toBeVisible();
+
+  await dayOnePage.exitWorkoutModalCancelButton.click();
+
+  await expect(dayOnePage.exitWorkoutModal).not.toBeVisible();
+  await expect(dayOnePage.dayHeading).toBeVisible();
+  await expect(dayOnePage.setsTable).toBeVisible();
+  await expect(dayOnePage.repInputLabel).toHaveText("SET 2 REPS");
+});
+
+test("confirming the exit warning leaves the workout and discards progress", async ({
+  page,
+}) => {
+  const dayOnePage = new DayOneWorkoutPage(page, 1);
+  await dayOnePage.startUserFlow();
+  await logOneSet(dayOnePage);
+  await page.goBack();
+  await expect(dayOnePage.exitWorkoutModal).toBeVisible();
+
+  await dayOnePage.exitWorkoutModalConfirmButton.click();
+
+  await expect(dayOnePage.exitWorkoutModal).not.toBeVisible();
+  await expect(page).toHaveURL(/\/program$/);
+});
+
+test("Escape key cancels the exit warning", async ({ page }) => {
+  const dayOnePage = new DayOneWorkoutPage(page, 1);
+  await dayOnePage.startUserFlow();
+  await logOneSet(dayOnePage);
+  await page.goBack();
+  await expect(dayOnePage.exitWorkoutModal).toBeVisible();
+
+  await page.keyboard.press("Escape");
+
+  await expect(dayOnePage.exitWorkoutModal).not.toBeVisible();
+  await expect(dayOnePage.dayHeading).toBeVisible();
+});
+
+test("after saving, the exit warning no longer appears on back navigation", async ({
+  page,
+}) => {
+  const dayOnePage = new DayOneWorkoutPage(page, 1);
+  await dayOnePage.startUserFlow();
+  await dayOnePage.pressPlusIcon(3);
+  for (let i = 0; i < 4; i++) {
+    await dayOnePage.pressCompleteSetButton();
+    await dayOnePage.timerModalCloseButton.waitFor({ state: "visible" });
+    await dayOnePage.closeTimerModal();
+  }
+  await dayOnePage.pressCompleteSetButton();
+  await expect(dayOnePage.dayCompleteArea).toBeVisible();
+  await dayOnePage.saveTheWorkout();
+  await expect(dayOnePage.dayCompleteMessage).toBeVisible();
+
+  // The guard's dummy history entry from before the save is still on the
+  // stack, so the first back-press after saving is absorbed without any
+  // visible change; the second press performs the real navigation.
+  await page.goBack();
+  await expect(dayOnePage.exitWorkoutModal).not.toBeVisible();
+  await expect(dayOnePage.dayHeading).toBeVisible();
+
+  await page.goBack();
+  await expect(dayOnePage.exitWorkoutModal).not.toBeVisible();
+  await expect(dayOnePage.dayHeading).not.toBeVisible();
+});

--- a/tests/pom/mixins/baseWorkoutPage.ts
+++ b/tests/pom/mixins/baseWorkoutPage.ts
@@ -23,6 +23,9 @@ export function MixinBaseWorkoutPage() {
     readonly dayCompleteSaveProgressMessage: Locator;
     readonly dayCompleteSaveButton: Locator;
     readonly dayCompleteGoBackLink: Locator;
+    readonly exitWorkoutModal: Locator;
+    readonly exitWorkoutModalCancelButton: Locator;
+    readonly exitWorkoutModalConfirmButton: Locator;
     indexForDays: number;
 
     constructor(page: Page, dayNumber: number) {
@@ -59,6 +62,13 @@ export function MixinBaseWorkoutPage() {
       this.dayCompleteGoBackLink = page.getByRole("link", {
         name: CIRCLE_CHECK_BIG_ICON_MESSAGE,
       });
+      this.exitWorkoutModal = page.locator("div#exit-workout-modal");
+      this.exitWorkoutModalCancelButton = page.locator(
+        "button#exit-workout-modal-cancel-button",
+      );
+      this.exitWorkoutModalConfirmButton = page.locator(
+        "button#exit-workout-modal-confirm-button",
+      );
     }
 
     async goto() {


### PR DESCRIPTION
Back navigation (browser/hardware/gesture back) previously unmounted an in-progress workout with no warning, silently discarding unsaved reps/sets since all workout state lives in local React state until manually saved. Adds a shared history-trap hook and confirmation modal, wired into all four workout-type components.


Claude-Session: https://claude.ai/code/session_01Mn5fqwKdxteuZrdSTe1FWV