### PR TITLE
Fix pre-push port-3000 cleanup on macOS

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -4,10 +4,23 @@ Z40="0000000000000000000000000000000000000000"
 SPECS=""
 
 clear_port_3000() {
-  # lsof is unreliable in WSL2; use ss to detect and fuser to kill
-  if ss -tlnp 2>/dev/null | grep -q ':3000 '; then
+  # ss is the reliable detector on WSL2, where lsof can be flaky; ss doesn't
+  # exist on macOS, so fall back to lsof there.
+  local port_in_use=1
+  if command -v ss >/dev/null 2>&1; then
+    ss -tlnp 2>/dev/null | grep -q ':3000 ' && port_in_use=0
+  elif command -v lsof >/dev/null 2>&1; then
+    lsof -ti:3000 >/dev/null 2>&1 && port_in_use=0
+  fi
+  if [ "$port_in_use" -eq 0 ]; then
     echo "pre-push: clearing port 3000..."
-    fuser -k 3000/tcp 2>/dev/null || true
+    # psmisc's `fuser -k 3000/tcp` (Linux/WSL2) isn't understood by macOS's
+    # BSD fuser, which only operates on files/mount points — fall back to
+    # killing the PIDs lsof finds when the psmisc-style call fails.
+    if ! fuser -k 3000/tcp >/dev/null 2>&1; then
+      pids=$(lsof -ti:3000 2>/dev/null)
+      [ -n "$pids" ] && echo "$pids" | xargs kill -9 2>/dev/null
+    fi
     sleep 2
   fi
 }


### PR DESCRIPTION
clear_port_3000() detected stale servers with `ss`, which doesn't exist on macOS, so the check silently no-op'd and the hook's own production server would collide with a leftover one (EADDRINUSE, stale-chunk failures). Falls back to lsof for detection and to lsof+kill when psmisc-style `fuser -k 3000/tcp` isn't supported.


Claude-Session: https://claude.ai/code/session_01Mn5fqwKdxteuZrdSTe1FWV