### PR TITLE
Support workout-history export on iOS PWA and fix Chrome desktop shar…

### DIFF
--- a/src/app/lib/utils.ts
+++ b/src/app/lib/utils.ts
@@ -8,13 +8,3 @@ export async function getAllDailyInstructions(): Promise<TDailyInstruction[]> {
 export const isSingular = (count: number): boolean => {
   return count === 1;
 };
-
-export const isSafari = () => {
-  const ua = navigator.userAgent;
-  return /^((?!chrome|android).)*safari/i.test(ua);
-};
-
-export const isChrome = () => {
-  const ua = navigator.userAgent;
-  return /chrome/i.test(ua) && !isSafari();
-};

--- a/src/components/program/DownloadDataButton.tsx
+++ b/src/components/program/DownloadDataButton.tsx
@@ -1,31 +1,20 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { nunito } from "@/fonts";
 import styles from "./DownloadDataButton.module.css";
 import { getOverallProgess } from "@/indexedDBActions";
-import { isSafari } from "@/utils";
 import DownloadDataModal from "./DownloadDataModal";
 
 const DownloadDataButton = () => {
-  const [showButton, setShowButton] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
+  const [saveError, setSaveError] = useState(false);
 
-  useEffect(() => {
-    if (!isSafari()) {
-      setShowButton(true);
-    }
-  }, []);
-
-  async function handleDownload() {
-    const data = await getOverallProgess();
-    const json = JSON.stringify(data, null, 2);
-    const blob = new Blob([json], { type: "application/json" });
-    const url = URL.createObjectURL(blob);
-
+  function downloadViaAnchor(file: File) {
+    const url = URL.createObjectURL(file);
     const a = document.createElement("a");
     a.href = url;
-    a.download = "Pull-Up-App-Backup.json";
+    a.download = file.name;
     a.style.display = "none";
 
     document.body.appendChild(a);
@@ -33,10 +22,44 @@ const DownloadDataButton = () => {
 
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
-    setModalOpen(false);
   }
 
-  if (!showButton) return;
+  async function handleDownload() {
+    setSaveError(false);
+    try {
+      const data = await getOverallProgess();
+      const json = JSON.stringify(data, null, 2);
+      const file = new File([json], "Pull-Up-App-Backup.json", {
+        type: "application/json",
+      });
+
+      if (
+        typeof navigator.canShare === "function" &&
+        navigator.canShare({ files: [file] })
+      ) {
+        try {
+          await navigator.share({ files: [file] });
+        } catch (shareErr) {
+          if (shareErr instanceof Error && shareErr.name === "AbortError") {
+            // User cancelled the native share sheet — not a failure.
+            setModalOpen(false);
+            return;
+          }
+          // Web Share can reject even when canShare() returned true — e.g.
+          // Chrome enforces stricter transient-activation rules than
+          // WebKit and can reject share() once an awaited call (like the
+          // IndexedDB read above) has happened first. Fall back to a
+          // direct download rather than leaving the user with nothing.
+          downloadViaAnchor(file);
+        }
+      } else {
+        downloadViaAnchor(file);
+      }
+      setModalOpen(false);
+    } catch {
+      setSaveError(true);
+    }
+  }
 
   return (
     <>
@@ -51,8 +74,12 @@ const DownloadDataButton = () => {
       </button>
       {modalOpen && (
         <DownloadDataModal
-          onClose={() => setModalOpen(false)}
+          onClose={() => {
+            setModalOpen(false);
+            setSaveError(false);
+          }}
           onConfirm={handleDownload}
+          saveError={saveError}
         />
       )}
     </>

--- a/src/components/program/DownloadDataModal.tsx
+++ b/src/components/program/DownloadDataModal.tsx
@@ -1,4 +1,5 @@
-import { useEffect } from "react";
+import { Fragment, useEffect } from "react";
+import Link from "next/link";
 import { DownloadIcon } from "lucide-react";
 import { nunito, ptSans } from "@/fonts";
 import styles from "./DownloadDataModal.module.css";
@@ -6,9 +7,14 @@ import styles from "./DownloadDataModal.module.css";
 interface DownloadDataModalProps {
   onClose: () => void;
   onConfirm: () => void;
+  saveError?: boolean;
 }
 
-const DownloadDataModal = ({ onClose, onConfirm }: DownloadDataModalProps) => {
+const DownloadDataModal = ({
+  onClose,
+  onConfirm,
+  saveError,
+}: DownloadDataModalProps) => {
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
       if (e.key === "Escape") onClose();
@@ -27,12 +33,28 @@ const DownloadDataModal = ({ onClose, onConfirm }: DownloadDataModalProps) => {
     >
       <div className={styles.dialog}>
         <DownloadIcon className={styles.icon} />
-        <h2 id="download-modal-heading" style={nunito.style} className={styles.heading}>
+        <h2
+          id="download-modal-heading"
+          style={nunito.style}
+          className={styles.heading}
+        >
           Download Workout History
         </h2>
-        <p className={styles.message} style={ptSans.style}>
-          Your workout history will be saved as a JSON file. You can use this
-          file to back up or transfer your data.
+        <p
+          id={saveError ? "download-modal-error" : undefined}
+          className={styles.message}
+          style={ptSans.style}
+        >
+          {saveError ? (
+            <Fragment>
+              Download failed — please try again, or email{" "}
+              <Link href={"mailto:support@repyourself.app"}>
+                support@repyourself.app
+              </Link>
+            </Fragment>
+          ) : (
+            "Your workout history will be saved as a JSON file. You can use this file to back up or transfer your data."
+          )}
         </p>
         <div className={styles.actions}>
           <button

--- a/tests/pom/mockShare.ts
+++ b/tests/pom/mockShare.ts
@@ -1,0 +1,64 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Forces the <a download> fallback path by making the Web Share API
+ * unavailable, regardless of what the underlying browser engine actually
+ * supports. Never let a test rely on the real navigator.share/canShare —
+ * calling those for real in headless/automated Chromium risks hanging on
+ * a native OS share surface that never resolves.
+ */
+export async function stubWebShareUnavailable(page: Page) {
+  await page.addInitScript(() => {
+    Object.defineProperty(window.navigator, "canShare", {
+      value: undefined,
+      configurable: true,
+    });
+    Object.defineProperty(window.navigator, "share", {
+      value: undefined,
+      configurable: true,
+    });
+  });
+}
+
+/**
+ * Forces the Web Share branch, with navigator.share either resolving
+ * ("share succeeded") or rejecting with a synthetic AbortError (user
+ * cancelled the native share sheet) — the real API is never invoked.
+ */
+export async function stubWebShareAvailable(
+  page: Page,
+  options: { resolve: boolean },
+) {
+  await page.addInitScript((shouldResolve) => {
+    Object.defineProperty(window.navigator, "canShare", {
+      value: () => true,
+      configurable: true,
+    });
+    Object.defineProperty(window.navigator, "share", {
+      value: () =>
+        shouldResolve
+          ? Promise.resolve()
+          : Promise.reject(
+              Object.assign(new Error("cancelled"), { name: "AbortError" }),
+            ),
+      configurable: true,
+    });
+  }, options.resolve);
+}
+
+/**
+ * Forces the Web Share branch, with navigator.share rejecting with a
+ * genuine (non-Abort) error, to exercise the failure/error-message path.
+ */
+export async function stubWebShareFailure(page: Page) {
+  await page.addInitScript(() => {
+    Object.defineProperty(window.navigator, "canShare", {
+      value: () => true,
+      configurable: true,
+    });
+    Object.defineProperty(window.navigator, "share", {
+      value: () => Promise.reject(new Error("boom")),
+      configurable: true,
+    });
+  });
+}

--- a/tests/pom/program-page.ts
+++ b/tests/pom/program-page.ts
@@ -20,6 +20,7 @@ export class ProgramPage {
   readonly downloadModal: Locator;
   readonly downloadModalCancelButton: Locator;
   readonly downloadModalConfirmButton: Locator;
+  readonly downloadModalErrorMessage: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -52,6 +53,7 @@ export class ProgramPage {
     this.downloadModalConfirmButton = page.locator(
       "#download-modal-confirm-button",
     );
+    this.downloadModalErrorMessage = page.locator("#download-modal-error");
   }
 
   async goto() {
@@ -89,5 +91,9 @@ export class ProgramPage {
   async cancelDownload() {
     await this.downloadModalCancelButton.click();
     await this.downloadModal.waitFor({ state: "hidden" });
+  }
+
+  async confirmDownload() {
+    await this.downloadModalConfirmButton.click();
   }
 }

--- a/tests/programPage.spec.ts
+++ b/tests/programPage.spec.ts
@@ -1,5 +1,6 @@
 import { ProgramPage } from "./pom/program-page";
 import { test, expect } from "@playwright/test";
+import { stubWebShareAvailable, stubWebShareFailure } from "./pom/mockShare";
 
 test("expect correct elements", async ({ page }) => {
   const programPage = new ProgramPage(page);
@@ -122,4 +123,51 @@ test("download modal cancel closes without downloading", async ({ page }) => {
   await programPage.cancelDownload();
   await expect(programPage.downloadModal).not.toBeVisible();
   await expect(programPage.pastWorkoutsHeader).toBeVisible();
+});
+
+test("download succeeds via Web Share API when available", async ({ page }) => {
+  // Never let a test touch the real navigator.share — stub it so this
+  // deterministically exercises the share branch without ever risking a
+  // hang on a native OS share surface in headless/automated Chromium.
+  await stubWebShareAvailable(page, { resolve: true });
+  const programPage = new ProgramPage(page);
+  await programPage.goto();
+  await programPage.pressSkipButton();
+  await programPage.pressDownloadButton();
+  await expect(programPage.downloadModal).toBeVisible();
+  await programPage.confirmDownload();
+  await expect(programPage.downloadModal).not.toBeVisible();
+  await expect(programPage.downloadModalErrorMessage).not.toBeVisible();
+});
+
+test("download modal closes silently when share is cancelled", async ({
+  page,
+}) => {
+  await stubWebShareAvailable(page, { resolve: false });
+  const programPage = new ProgramPage(page);
+  await programPage.goto();
+  await programPage.pressSkipButton();
+  await programPage.pressDownloadButton();
+  await expect(programPage.downloadModal).toBeVisible();
+  await programPage.confirmDownload();
+  await expect(programPage.downloadModal).not.toBeVisible();
+  await expect(programPage.downloadModalErrorMessage).not.toBeVisible();
+});
+
+test("download falls back to a direct download when Web Share fails", async ({
+  page,
+}) => {
+  // Some browsers (e.g. Chrome, which enforces stricter transient-activation
+  // rules than WebKit) can report canShare() as true but still reject the
+  // actual share() call. That should silently fall back to the classic
+  // <a download> path rather than leaving the user with an error.
+  await stubWebShareFailure(page);
+  const programPage = new ProgramPage(page);
+  await programPage.goto();
+  await programPage.pressSkipButton();
+  await programPage.pressDownloadButton();
+  await expect(programPage.downloadModal).toBeVisible();
+  await programPage.confirmDownload();
+  await expect(programPage.downloadModal).not.toBeVisible();
+  await expect(programPage.downloadModalErrorMessage).not.toBeVisible();
 });


### PR DESCRIPTION
…e failure

The download button used to hide itself entirely on Safari via a UA sniff, added back when there was no iOS app to migrate data into. Now that iOS has a real import feature whose file-picker flow assumes Safari downloads work, replace the identity-based gate with a capability check: use the Web Share API (native share sheet, reliable on iOS/WebKit) when available, falling back to the existing <a download>+blob path otherwise.

Also fixes a real regression found via live testing: Chrome enforces stricter transient-activation rules than WebKit and rejected navigator.share() with NotAllowedError once the awaited IndexedDB read happened first. Any Web Share failure other than the user explicitly cancelling now falls back to the direct download instead of erroring.


Claude-Session: https://claude.ai/code/session_01VT2h5Eqpb9YuBfKC4LNFGJ