### PR TITLE
Fix pre-push hook crashing when deleting a remote branch

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -28,6 +28,11 @@ clear_port_3000() {
 trap clear_port_3000 EXIT
 
 while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
+  if [ "$local_sha" = "$Z40" ]; then
+    echo "pre-push: deleting remote ref $remote_ref — skipping tests"
+    continue
+  fi
+
   if [ "$remote_sha" = "$Z40" ]; then
     echo "pre-push: new branch — running full test suite"
     SPECS="tests/landingPage.spec.ts tests/programPage.spec.ts tests/dayOnePage.spec.ts tests/dayTwoPage.spec.ts tests/dayThreePage.spec.ts tests/dayFourPage.spec.ts tests/dayFivePage.spec.ts tests/dayReviewPage.spec.ts tests/fullWeek.spec.ts"


### PR DESCRIPTION
The hook only checked remote_sha == Z40 to detect a new branch push, but never checked local_sha == Z40 (a branch deletion). Deleting a remote branch made it compute git diff against the all-zero SHA, which is an invalid revision range and crashed the hook, blocking the delete entirely.


Claude-Session: https://claude.ai/code/session_01VT2h5Eqpb9YuBfKC4LNFGJ