### PR TITLE
Fix /privacy and /support overflowing on mobile viewports

### DIFF
--- a/src/components/privacy/PrivacyPolicy.module.css
+++ b/src/components/privacy/PrivacyPolicy.module.css
@@ -1,4 +1,5 @@
 .privacyPolicy {
+  width: 100%;
   max-width: 37.5rem;
   display: flex;
   flex-direction: column;

--- a/src/components/support/Support.module.css
+++ b/src/components/support/Support.module.css
@@ -1,4 +1,5 @@
 .support {
+  width: 100%;
   max-width: 37.5rem;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
.main (layout.module.css) uses justify-items: center, so its child content box isn't stretched to the track width and instead sizes to its own shrink-to-fit width. A long unbroken URL in PrivacyPolicy.tsx wasn't broken by overflow-wrap: break-word during max-content sizing, pushing the box past the viewport; centered and clipped by the global overflow-x: hidden, this cut text off on both edges on mobile.

Support.module.css shares the same latent bug (verified via Playwright at iPhone SE width) even though no content currently triggers it.

Adding width: 100% to both content boxes forces them to fill their grid track regardless of content, while max-width still caps and centers them on desktop as before.